### PR TITLE
Don't generate addresses for uncompressed pks

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,10 @@ function details(){
     var NETWORK = currentNetwork();
     var wif = wifPrivateKey;
     var keyPair = bitcoin.ECPair.fromWIF(wif, NETWORK);
+    if (!keyPair.compressed) {
+      alert("Segwit supports only compressed public keys");
+      return;
+    }
     var pubKey = keyPair.getPublicKeyBuffer();
     var pubKeyHash = bitcoin.crypto.hash160(pubKey);
     var pubKeyHex = pubKey.toString('hex');


### PR DESCRIPTION
Right now when showing the details of a WIF private key, if you were to paste a uncompressed WIF (without a extra 0x01 at the end of the private key) it would generate a Segwit address using the uncompressed public key, and if you sent money to that address it would not be possible to spend the outputs anymore.

Can be tested with the following WIFs: 
Uncompressed WIF: 5J4wcorpQrZaFV2Gwfuw4NrHotDnXT3Hd5WKguVFRBaarEvdaCU
Equivalent Compressed WIF: KxLQ53ptGHkmkvgdNJkdbuSZBw5RwPw6NEtRV8fgdjhEQG62526K